### PR TITLE
First attempt at adding custom weighting matrix support

### DIFF
--- a/inference_vb.cc
+++ b/inference_vb.cc
@@ -595,6 +595,11 @@ void Vb::DoCalculationsSpatial(FabberRunData &rundata)
     // Make the neighbours lists if required
     rundata.GetNeighbours(m_ctx->neighbours, m_ctx->neighbours2);
 
+    if (UseLaplacian(rundata))
+    {
+        rundata.GetWeightings(m_ctx->weightings, m_ctx->neighbours, *m_laplacian);
+    }
+
     vector<Parameter> params;
     m_model->GetParameters(rundata, params);
     vector<Prior *> priors = PriorFactory(rundata).CreatePriors(params);
@@ -632,14 +637,7 @@ void Vb::DoCalculationsSpatial(FabberRunData &rundata)
                 // Apply prior updates for spatial or ARD priors
                 for (int k = 0; k < m_num_params; k++)
                 {
-                    if (UseLaplacian(rundata))
-                    {
-                        Fprior += priors[k]->ApplyToMVN(&m_ctx->fwd_prior[v - 1], *m_ctx, m_laplacian->Column(v));
-                    }
-                    else
-                    {
-                        Fprior += priors[k]->ApplyToMVN(&m_ctx->fwd_prior[v - 1], *m_ctx);
-                    }
+                    Fprior += priors[k]->ApplyToMVN(&m_ctx->fwd_prior[v - 1], *m_ctx);
                 }
                 if (m_debug)
                     DebugVoxel(v, "Priors set");

--- a/inference_vb.h
+++ b/inference_vb.h
@@ -67,6 +67,11 @@ protected:
     bool IsSpatial(FabberRunData &rundata) const;
 
     /**
+     * Determine whether we are providing a Laplacian weighting matrix.
+     */
+    bool UseLaplacian(FabberRunData &rundata) const;
+
+    /**
      * Do calculations loop in voxelwise mode (i.e. all iterations for
      * one voxel, then all iterations for the next voxel, etc)
      */
@@ -147,6 +152,9 @@ protected:
 
     /** Voxelwise supplementary data */
     const NEWMAT::Matrix *m_suppdata;
+
+    /** NxN Laplacian weighting matrix */
+    const NEWMAT::Matrix *m_laplacian;
 
     /** Number of motion correction steps to run */
     int m_num_mcsteps;

--- a/priors.cc
+++ b/priors.cc
@@ -533,7 +533,6 @@ double SpatialPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEW
     {
         assert(nn <= m_spatial_dims * 2);
         nn = 2 * m_spatial_dims;
-        nn2 = 4 * m_spatial_dims * m_spatial_dims - nn;
     }
 
     // Prior precision
@@ -589,7 +588,6 @@ double SpatialPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEW
     {
         double rec = - 1 / (total_weight + 1e-8);
         spatial_mean = contrib_nn * rec;
-    }
     }
     else
         spatial_mean = 0;

--- a/priors.cc
+++ b/priors.cc
@@ -287,6 +287,7 @@ double SpatialPrior::CalculateaK(const RunContext &ctx)
             if (m_type_code == PRIOR_SPATIAL_l)
             {
                 double weight = ctx.weightings[v-1][*v2It-1];
+                // + instead of - because the weights are already negative
                 SwK += wK + weight*ctx.fwd_post.at(*v2It - 1).means(m_idx + 1);
             }
             else

--- a/priors.cc
+++ b/priors.cc
@@ -116,6 +116,17 @@ double DefaultPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx)
     return 0;
 }
 
+double DefaultPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings)
+{
+    prior->means(m_idx + 1) = m_params.mean();
+
+    SymmetricMatrix prec = prior->GetPrecisions();
+    prec(m_idx + 1, m_idx + 1) = m_params.prec();
+    prior->SetPrecisions(prec);
+
+    return 0;
+}
+
 ImagePrior::ImagePrior(const Parameter &p, FabberRunData &rundata)
     : DefaultPrior(p)
 {
@@ -451,6 +462,134 @@ double SpatialPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx)
     {
         double rec = 1 / (8*nn - nn2);
         spatial_mean = (contrib_nn + contrib_nn2) * rec;
+    }
+    else
+        spatial_mean = 0;
+
+    if (m_type_code == PRIOR_SPATIAL_m || m_type_code == PRIOR_SPATIAL_M)
+    {
+        // These priors do not take account of the original parameter prior mean at all - 
+        // the prior mean is determined entirely by the expectation of spatial uniformity
+        // compared to neighbouring voxels.
+        //
+        // For prior type m this reduces to spatial_mean since the covariance is in this 
+        // case simply the reciprocal of the spatial precision
+        prior->means(m_idx + 1) = prior->GetCovariance()(m_idx + 1, m_idx + 1) * spatial_prec
+            * spatial_mean;
+    }
+    else
+    {
+        // These priors include the original parameter prior mean as well as the values of 
+        // the parameter at neighbouring voxels.
+        //
+        // For prior type p, this reduces to spatial_mean + spatial_cov * original_prec * original_mean
+        // For a weak original non-spatial prior (i.e. m_params->prec is small)  this reduces to
+        // the spatial spatial_mean, 
+        prior->means(m_idx + 1) = prior->GetCovariance()(m_idx + 1, m_idx + 1)
+            * (spatial_prec * spatial_mean + m_params.prec() * m_params.mean());
+    }
+
+    // Spatial prior does not contribute to the free energy?
+    // Technically I think it should via the prior on ak (q1, q2) however since this is uninformative
+    // it may not matter.
+    return 0;
+}
+
+double SpatialPrior::ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings)
+{
+    // Comments and theory notes are from MSC and should not be trusted
+
+    if (ctx.v == 1 && (ctx.it > 0 || m_update_first_iter))
+    {
+        // m_aK is a global (all voxels) spatial precision variable for 
+        // the parameter. It determines the degree of smoothness
+        // and is estimated from the data. We update it on the first
+        // voxel (unless it is the first iteration and m_update_first_iter 
+        // is false). See Penny et all 2004
+        m_aK = CalculateaK(ctx);
+    }
+
+    // Loop over nearest neighbours of the current voxel
+    // These are weighted according to the Laplacian matrix passed in via the command line
+    int nn = ctx.neighbours[ctx.v - 1].size();
+    double contrib_nn = 0.0;
+    double total_weight = 0.0;
+    for (vector<int>::const_iterator nidIt = ctx.neighbours[ctx.v - 1].begin();
+         nidIt != ctx.neighbours[ctx.v - 1].end(); ++nidIt)
+    {
+        int nid = *nidIt;
+        const MVNDist &neighbourPost = ctx.fwd_post[nid - 1];
+        double weight = weightings.element(nid-1);
+        total_weight += weight;
+        contrib_nn += nid * neighbourPost.means(m_idx + 1);
+    }
+
+    // In priors without boundary correction, the number of neighbours is fixed by
+    // the spatial dimensions, although this is not correct at the edges of the volume
+    // The contributions from first and second neighbours are unchanged - this is
+    // equivalent to the 'missing' voxels outside the boundary having value 0
+    // (hence biased towards zero as noted in Penny 2005).
+    if ((m_type_code == PRIOR_SPATIAL_p) || (m_type_code == PRIOR_SPATIAL_m))
+    {
+        assert(nn <= m_spatial_dims * 2);
+        nn = 2 * m_spatial_dims;
+        nn2 = 4 * m_spatial_dims * m_spatial_dims - nn;
+    }
+
+    // Prior precision
+    //
+    // The precision of the prior depends on the degree of spatial regularization
+    // (m_aK) and the number of neighbours.
+     
+    // Calculate spatial precision for each prior type. Note the 1e-8 contribution
+    // for the MRF prior, this is to ensure invertibility?
+    double spatial_prec = 0;
+    if (m_type_code == PRIOR_SPATIAL_M)
+        spatial_prec = m_aK * (nn + 1e-8);
+    else if (m_type_code == PRIOR_SPATIAL_m)
+        spatial_prec = m_aK * nn;
+    else if ((m_type_code == PRIOR_SPATIAL_P) || (m_type_code == PRIOR_SPATIAL_p))
+        spatial_prec = m_aK * (nn * nn + nn);
+    else
+        assert(false);
+
+    SymmetricMatrix precs = prior->GetPrecisions();
+    if ((m_type_code == PRIOR_SPATIAL_p) || (m_type_code == PRIOR_SPATIAL_m))
+    {
+        // Penny-style DirichletBC prior ignores original prior precision completely
+        precs(m_idx + 1, m_idx + 1) = spatial_prec;
+    }
+    else
+    {
+        // All other priors set a prior precision based on the sum of the original
+        // prior precision and the spatial precision - i.e. spatial smoothing
+        // makes prior more informative
+        precs(m_idx + 1, m_idx + 1) = m_params.prec() + spatial_prec;
+    }
+    prior->SetPrecisions(precs);
+
+    // Prior mean
+    //
+    // The prior mean depends on the degree of spatial regularization (which has been
+    // absorbed into the prior precision/covariance matrix). It may also reflect the
+    // original prior mean for the parameter, i.e. spatial regularization does not completely
+    // override the original prior mean.
+
+    // NB that we multiply by reciprocals rather than dividing. This is
+    // to maximise numerical compatibility with NEWMAT which presumably
+    // does it as an optimization when dividing a whole matrix by a constant
+    double spatial_mean;
+    if (m_type_code == PRIOR_SPATIAL_m)
+    {
+        // Dirichlet BCs on MRF i.e. no boundary correction
+        double rec = - 1 / total_weight;
+        spatial_mean = contrib_nn * rec;
+    }
+    else if (m_type_code == PRIOR_SPATIAL_M)
+    {
+        double rec = - 1 / (total_weight + 1e-8);
+        spatial_mean = contrib_nn * rec;
+    }
     }
     else
         spatial_mean = 0;

--- a/priors.cc
+++ b/priors.cc
@@ -553,6 +553,6 @@ Prior *PriorFactory::CreatePrior(Parameter p)
     case PRIOR_ARD:
         return new ARDPrior(p, m_rundata);
     default:
-        throw InvalidOptionValue("Prior type", stringify(p.prior_type), "Supported types: NMmPpAI");
+        throw InvalidOptionValue("Prior type", stringify(p.prior_type), "Supported types: NMmlPpAI");
     }
 }

--- a/priors.h
+++ b/priors.h
@@ -44,6 +44,7 @@ public:
      * Returns any additional free energy contribution (e.g. for ARD priors)
      */
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx) = 0;
+    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings) = 0;
 
     /** Expand the param-spatial-priors string to give a value for each parameter */
     static std::string ExpandPriorTypesString(std::string priors_str, unsigned int num_params);
@@ -73,6 +74,7 @@ public:
 
     virtual void DumpInfo(std::ostream &out) const;
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx);
+    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings);
 };
 
 /**
@@ -123,6 +125,7 @@ public:
 
     virtual void DumpInfo(std::ostream &out) const;
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx);
+    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings);
 
 protected:
     double CalculateaK(const RunContext &ctx);

--- a/priors.h
+++ b/priors.h
@@ -24,6 +24,7 @@ const char PRIOR_SPATIAL_M = 'M'; // Markov random field - normally used
 const char PRIOR_SPATIAL_m = 'm'; // 'M' with Dirichlet BCs
 const char PRIOR_SPATIAL_P = 'P'; // Alternative to M (Penny prior?)
 const char PRIOR_SPATIAL_p = 'p'; // P with Dirichlet BCs
+const char PRIOR_SPATIAL_l = 'l'; // laplacian weightings
 const char PRIOR_DEFAULT = '-';   // Use whatever the model specifies
 
 /**
@@ -44,7 +45,6 @@ public:
      * Returns any additional free energy contribution (e.g. for ARD priors)
      */
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx) = 0;
-    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings) = 0;
 
     /** Expand the param-spatial-priors string to give a value for each parameter */
     static std::string ExpandPriorTypesString(std::string priors_str, unsigned int num_params);
@@ -74,7 +74,6 @@ public:
 
     virtual void DumpInfo(std::ostream &out) const;
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx);
-    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings);
 };
 
 /**
@@ -125,7 +124,6 @@ public:
 
     virtual void DumpInfo(std::ostream &out) const;
     virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx);
-    virtual double ApplyToMVN(MVNDist *prior, const RunContext &ctx, const NEWMAT::ColumnVector &weightings);
 
 protected:
     double CalculateaK(const RunContext &ctx);

--- a/run_context.h
+++ b/run_context.h
@@ -47,4 +47,5 @@ struct RunContext
     std::vector<NoiseParams *> noise_post;
     std::vector<std::vector<int> > neighbours;
     std::vector<std::vector<int> > neighbours2;
+    std::vector<std::vector<double> > weightings;
 };

--- a/rundata.cc
+++ b/rundata.cc
@@ -1025,6 +1025,18 @@ void FabberRunData::GetNeighbours(std::vector<std::vector<int> > &neighbours,
     neighbours2.resize(nvoxels);
 }
 
+void FabberRunData::GetWeightings(std::vector<std::vector<double> > &weightings, 
+                                  std::vector<std::vector<int> > &neighbours,
+                                  const NEWMAT::Matrix &m_laplacian)
+{
+    WARN_ONCE("FabberRunData::GetWeightings default implementation returns no weightings");
+    
+    const Matrix &coords = GetVoxelCoords();
+    const int nvoxels = coords.Ncols();
+
+    weightings.resize(nvoxels);
+}
+
 void FabberRunData::CheckSize(std::string key, const NEWMAT::Matrix &mat)
 {
     if (m_voxel_data.size() > 0)

--- a/rundata.cc
+++ b/rundata.cc
@@ -829,6 +829,30 @@ const NEWMAT::Matrix &FabberRunData::GetVoxelData(const std::string &key)
     return m;
 }
 
+const NEWMAT::Matrix &FabberRunData::GetLaplacian(const std::string &key)
+{
+    // Attempt to load Laplacian weighting matrix if not 
+    // already present. Will throw an exception if parameter 
+    // not specified or file could not be loaded
+    //
+    // FIXME different exceptions? What about use case where
+    // Laplacian is optional?
+    string key_cur = key;
+    string lap_key = "";
+    while (key_cur != "")
+    {
+        lap_key = key_cur;
+        key_cur = GetStringDefault(key_cur, "");
+        // Avoid possible circular reference!
+        if (key_cur == key)
+            break;
+    }
+
+    const NEWMAT::Matrix &m = LoadVoxelData(lap_key);
+    LOG << "FabberRunData::GetLaplacian: " << key << "=" << lap_key << endl;
+    return m;
+}
+
 const NEWMAT::Matrix &FabberRunData::LoadVoxelData(const std::string &key)
 {
     if (m_voxel_data.count(key) == 0)

--- a/rundata.cc
+++ b/rundata.cc
@@ -161,6 +161,7 @@ static OptionSpec OPTIONS[] = {
     { "loadmodels", OPT_FILE,
         "Load models dynamically from the specified filename, which should be a DLL/shared library",
         OPT_NONREQ, "" },
+    { "laplacian", OPT_MATRIX, "Provide a weighting matrix for the spatial prior", OPT_NONREQ, ""},
     { "surface", OPT_FILE, "Specify a GIFTI surface file on which data is defined. If this option is used all voxel data files are assumed to be GIFTI files defined on the same surface", OPT_NONREQ, "" },
     { "data", OPT_TIMESERIES, "Specify a single input data file", OPT_REQ, "" },
     { "data<n>", OPT_TIMESERIES, "Specify multiple data files for n=1, 2, 3...", OPT_NONREQ, "" },

--- a/rundata.h
+++ b/rundata.h
@@ -469,6 +469,32 @@ public:
     const NEWMAT::Matrix &GetVoxelData(const std::string &key);
 
     /**
+     * Get named Laplacian weighting matrix
+     *
+     * GetLaplacian will check recursively for a string option with this key
+     * until it can resolve the key no further. The last non-empty key will
+     * then be used to request data from the FabberIo instance.
+     *
+     * For example, if GetLaplacian("lap") is called, we first check for a
+     * string option with key "lap". If this option is set to "fmri_data",
+     * then we check for a string option with key "fmri_data", and so on.
+     * If no option with key "fmri_data" is found, we ask our FabberIo instance
+     * to get the data with key "fmri_data", which it might, for example,
+     * load from a file fmri_data.nii.gz.
+     *
+     * This sounds complicated, but actually simplifies situations such as
+     * restarting runs from a file, where the restart might come from memory
+     * saved data, or an external file.
+     *
+     * @param key Name identifying the voxel data required.
+     * @return an NxN matrix where each column contains the weightings for 
+     *         a single voxel.
+     * @throw DataNotFound If no voxel data matching key is found and no data
+     *                     could be loaded
+     */
+    const NEWMAT::Matrix &GetLaplacian(const std::string &key);
+
+    /**
      * Get named voxel data, with no further resolution of the name.
      *
      * Can be overridden in a subclass to, for example, load data from

--- a/rundata.h
+++ b/rundata.h
@@ -586,6 +586,18 @@ public:
                                std::vector<std::vector<int> > &neighbours2);
 
     /**
+     * Get list of weightings for each neighbour for each voxel
+     *
+     * The list will contain voxel indices for matrices, i.e. starting at 1 not 0
+     * 
+     * This should be implemented by subclasses. The default implementation returns 
+     * no neighbours for any voxel (but correctly sized output vectors).
+     */
+    virtual void GetWeightings(std::vector<std::vector<double> > &weightings, 
+                               std::vector<std::vector<int> > &neighbours,
+                               const NEWMAT::Matrix &m_laplacian);
+
+    /**
      * Report progress
      *
      * InferenceMethods call this to report how many voxels

--- a/rundata_gifti.cc
+++ b/rundata_gifti.cc
@@ -229,4 +229,3 @@ void FabberRunDataGifti::GetNeighbours(std::vector<std::vector<int> > &neighbour
         //cout << endl;
     }
 }
-

--- a/rundata_gifti.cc
+++ b/rundata_gifti.cc
@@ -229,3 +229,31 @@ void FabberRunDataGifti::GetNeighbours(std::vector<std::vector<int> > &neighbour
         //cout << endl;
     }
 }
+
+void FabberRunDataGifti::GetWeightings(std::vector<std::vector<double> > &weightings,
+                                       std::vector<std::vector<int> > &neighbours,
+                                       const NEWMAT::Matrix &m_laplacian)
+{
+    LOG << "FabberRunDataGifti::Getting Laplacian weightings for neighbours" << endl;
+
+    int nv = m_surface.getNumberOfVertices();
+    weightings.clear();
+    weightings.resize(nv);
+
+    // iterate over each vertex
+    for (unsigned int vid=1; vid <= nv; vid++)
+    {   
+        ColumnVector v_weights = m_laplacian.Column(vid);
+        // iterate over neighbours of this vertex
+        // this only assigns weightings for neighbouring values, not own weighting
+        for (unsigned int n2=0; n2<neighbours[vid-1].size(); n2++)
+        {
+            // get weightings for vertex/neighbour combination from Laplacian matrix
+            double weight = v_weights.element(n2);
+            weightings[vid-1].push_back(weight);
+        }
+        // also add the weighting for this vertex
+        double weight = v_weights.element(vid-1);
+        weightings[vid-1].push_back(weight);
+    }
+}

--- a/rundata_gifti.h
+++ b/rundata_gifti.h
@@ -39,6 +39,9 @@ public:
         const std::string &filename, NEWMAT::Matrix &data, VoxelDataType data_type = VDT_SCALAR);
     void GetNeighbours(std::vector<std::vector<int> > &neighbours, 
                        std::vector<std::vector<int> > &neighbours2);
+    void GetWeightings(std::vector<std::vector<double> > &weightings, 
+                       std::vector<std::vector<int> > &neighbours,
+                       const NEWMAT::Matrix &m_laplacian);
 private:
     void SetCoordsFromSurface();
     fslsurface_name::fslSurface<float, unsigned int> m_surface;


### PR DESCRIPTION
Loads custom weighting matrix. In a similar way to how the list of lists of neighbouring nodes is created, this should create a list of lists of weights for each of these neighbours from the provided weighting matrix. This should then be utilised in priors.cc.